### PR TITLE
Warm up webservice token cache during startup

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/WebserviceService.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/WebserviceService.java
@@ -56,6 +56,14 @@ public class WebserviceService {
         return mapToDto(data);
     }
 
+    /**
+     * Prepara o cache do token garantindo que um token válido esteja disponível.
+     * A chamada é idempotente, pois reutiliza o token em cache quando ainda válido.
+     */
+    public void prepareTokenCache() {
+        obterTokenValido().block();
+    }
+
     private Mono<UserDTO> buscarMilitarComTokenRenovado(String cpf) {
         return obterTokenValido()
                 .flatMap(token -> ccabrService.buscarMilitar(cpf, token)

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/WebserviceWarmup.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/WebserviceWarmup.java
@@ -1,0 +1,39 @@
+package intraer.ccabr.barbearia_api.services;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebserviceWarmup {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebserviceWarmup.class);
+
+    private final WebserviceService webserviceService;
+    private final boolean preloadToken;
+
+    public WebserviceWarmup(WebserviceService webserviceService,
+            @Value("${webservice.preload-token:true}") boolean preloadToken) {
+        this.webserviceService = webserviceService;
+        this.preloadToken = preloadToken;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void warmupTokenCache() {
+        if (!preloadToken) {
+            logger.info("Pré-carregamento do token do webservice desativado por configuração.");
+            return;
+        }
+
+        try {
+            webserviceService.prepareTokenCache();
+            logger.info("Cache de token do webservice preparado com sucesso durante o startup.");
+        } catch (Exception ex) {
+            logger.warn("Falha ao preparar o cache de token do webservice durante o startup: {}", ex.getMessage(), ex);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose a `prepareTokenCache` method so the webservice token can be eagerly cached
- add a `WebserviceWarmup` component that preloads the token on application startup and logs failures
- allow disabling the warmup through the `webservice.preload-token` property when needed

## Testing
- `./mvnw test` *(fails: existing compilation errors in AgendamentoServiceTest.java)*

------
https://chatgpt.com/codex/tasks/task_e_68dbea01948c832389321108f9d1339b