### PR TITLE
Configure BCrypt strength via property

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/infra/security/SecurityConfigurations.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/infra/security/SecurityConfigurations.java
@@ -1,6 +1,7 @@
 package intraer.ccabr.barbearia_api.infra.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -54,7 +55,7 @@ public class SecurityConfigurations {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+    public PasswordEncoder passwordEncoder(@Value("${security.bcrypt.strength:10}") int strength) {
+        return new BCryptPasswordEncoder(strength);
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,3 +1,7 @@
 spring:
   jpa:
     show-sql: true
+
+security:
+  bcrypt:
+    strength: 8

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,5 +41,11 @@ webservice:
   username: ${WEBSERVICE_USERNAME:barbearia}
   password: "${WEBSERVICE_PASSWORD:B@rber$h0p}"
 
+# O fator de custo do BCrypt controla o equilíbrio entre desempenho (logins mais rápidos)
+# e segurança (hashes mais resistentes a ataques de força bruta). Ajuste conforme a necessidade.
+security:
+  bcrypt:
+    strength: ${SECURITY_BCRYPT_STRENGTH:10}
+
 # server:
 #   port: ${SERVER_PORT:8081}


### PR DESCRIPTION
## Summary
- inject the BCrypt strength into the password encoder using a configurable property
- document the new security.bcrypt.strength setting and its performance versus security trade-off
- set the development profile to use a lower strength value for faster local logins

## Testing
- not run (manual authentication timing verification required)


------
https://chatgpt.com/codex/tasks/task_e_68dbec76bbb0832386e6a22f3420008b