### PR TITLE
Harden dashboard security rules

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/controllers/DashboardController.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/controllers/DashboardController.java
@@ -7,6 +7,7 @@ import intraer.ccabr.barbearia_api.models.Agendamento;
 import intraer.ccabr.barbearia_api.repositories.AgendamentoRepository;
 import intraer.ccabr.barbearia_api.repositories.HorarioRepository;
 import intraer.ccabr.barbearia_api.repositories.MilitarRepository;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/dashboard")
+@PreAuthorize("hasRole('ADMIN')")
 public class DashboardController {
 
     private final AgendamentoRepository agendamentoRepository;

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/infra/security/SecurityConfigurations.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/infra/security/SecurityConfigurations.java
@@ -41,8 +41,26 @@ public class SecurityConfigurations {
                     .requestMatchers(HttpMethod.POST, "/api/horarios/**").hasRole("ADMIN")
                     .requestMatchers(HttpMethod.GET, "/api/horarios/**").hasAnyRole("GRADUADO", "OFICIAL")
                     .requestMatchers("/api/militares/**").hasRole("ADMIN")
-                    .requestMatchers(HttpMethod.GET, "/**", "/assets.images/**", "/main*.js", "/runtime*.js", "/polyfills*.js", "/scripts*.js", "/styles*.css").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/agendamentos").hasAnyRole("ADMIN", "GRADUADO", "OFICIAL")
+                    .requestMatchers(
+                            HttpMethod.GET,
+                            "/",
+                            "/index.html",
+                            "/favicon.ico",
+                            "/manifest.webmanifest",
+                            "/assets/**",
+                            "/main*.js",
+                            "/runtime*.js",
+                            "/polyfills*.js",
+                            "/scripts*.js",
+                            "/styles*.css",
+                            "/3rdpartylicenses.txt",
+                            "/barber*.png",
+                            "/456*.js",
+                            "/665*.js",
+                            "/896*.js")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/**").authenticated()
                     .requestMatchers(HttpMethod.DELETE, "/api/horarios/**").hasRole("ADMIN")
                     .anyRequest().authenticated()
                 )

--- a/backend/src/test/java/intraer/ccabr/barbearia_api/security/SecurityConfigurationsIntegrationTest.java
+++ b/backend/src/test/java/intraer/ccabr/barbearia_api/security/SecurityConfigurationsIntegrationTest.java
@@ -1,0 +1,66 @@
+package intraer.ccabr.barbearia_api.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false",
+        "api.secret.token.secret=test-secret",
+        "webservice.preload-token=false"
+})
+class SecurityConfigurationsIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+    @Test
+    @DisplayName("Deve retornar 401 para acesso não autenticado ao dashboard")
+    void whenAccessDashboardWithoutAuthentication_thenReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/dashboard/stats"))
+                .andExpect(this::assertUnauthorizedOrForbidden);
+        mockMvc.perform(get("/api/dashboard/recent"))
+                .andExpect(this::assertUnauthorizedOrForbidden);
+    }
+
+    @Test
+    @DisplayName("Deve servir a página inicial e os assets públicos do Angular")
+    void whenAccessAngularStaticResources_thenReturnOk() throws Exception {
+        mockMvc.perform(get("/")).andExpect(status().isOk());
+        mockMvc.perform(get("/assets/images/barbearia.ico")).andExpect(status().isOk());
+
+        Resource[] bundles = resolver.getResources("classpath:/static/main*.js");
+        assertThat(bundles).isNotEmpty();
+        String mainBundleName = bundles[0].getFilename();
+        mockMvc.perform(get("/" + mainBundleName)).andExpect(status().isOk());
+    }
+
+    private void assertUnauthorizedOrForbidden(MvcResult result) {
+        int status = result.getResponse().getStatus();
+        assertThat(status)
+                .withFailMessage("Status esperado 401 ou 403, mas foi %s", status)
+                .isIn(HttpStatus.UNAUTHORIZED.value(), HttpStatus.FORBIDDEN.value());
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace the broad GET /** authorization rule with explicit Angular static asset matchers and require authentication for GET /api/**
- guard DashboardController with @PreAuthorize("hasRole('ADMIN')") for defense in depth
- add integration coverage to ensure dashboard endpoints return 401/403 to unauthenticated users and that Angular bundles remain public

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68dd33eb5be48323a221467c94fddd4f