### PR TITLE
Exibe dados formatados do militar em slots agendados na tabela semanal

### DIFF
--- a/frontend/src/app/components/agendamento/tabela-semanal/tabela-semanal.component.html
+++ b/frontend/src/app/components/agendamento/tabela-semanal/tabela-semanal.component.html
@@ -28,18 +28,26 @@
             </td>
             <td *ngFor="let dia of diasDaSemana; trackBy: trackByDia" class="tabela-coluna-dia">
               <ng-container *ngIf="getSlot(dia, hora, grade.horarios) as slot; else indisponivel">
-                <button
-                  mat-raised-button
-                  [disabled]="!podeInteragirComSlot(slot, dia, hora)"
-                  [color]="slot.status === 'DISPONIVEL' ? 'primary' : undefined"
-                  [ngClass]="[
-                    slot.status | statusFormat : 'tabelaClass',
-                    deveDestacarSlot(slot, dia, hora) ? 'botao-agendado-proprio' : ''
-                  ]"
-                  (click)="handleClick(getAgendamentoParaDiaHora(dia, hora), dia, hora)"
-                >
-                  {{ slot.status | statusFormat }}
-                </button>
+                <ng-container *ngIf="{ agendamento: getAgendamentoParaDiaHora(dia, hora) } as contexto">
+                  <button
+                    mat-raised-button
+                    [disabled]="!podeInteragirComSlot(slot, dia, hora)"
+                    [color]="slot.status === 'DISPONIVEL' ? 'primary' : undefined"
+                    [ngClass]="[
+                      slot.status | statusFormat : 'tabelaClass',
+                      deveDestacarSlot(slot, dia, hora) ? 'botao-agendado-proprio' : ''
+                    ]"
+                    [matTooltip]="slot.status === 'AGENDADO' ? getTextTooltip(contexto.agendamento) : undefined"
+                    (click)="handleClick(contexto.agendamento, dia, hora)"
+                  >
+                    <ng-container *ngIf="slot.status === 'AGENDADO'; else statusPadrao">
+                      {{ formatarMilitar(contexto.agendamento) }}
+                    </ng-container>
+                    <ng-template #statusPadrao>
+                      {{ slot.status | statusFormat }}
+                    </ng-template>
+                  </button>
+                </ng-container>
               </ng-container>
             </td>
           </tr>

--- a/frontend/src/app/components/agendamento/tabela-semanal/tabela-semanal.component.ts
+++ b/frontend/src/app/components/agendamento/tabela-semanal/tabela-semanal.component.ts
@@ -811,6 +811,22 @@ export class TabelaSemanalComponent implements OnInit, OnDestroy, OnChanges {
            `Ramal: ${agendamento.militar?.ramal || 'Não informado'}`;
   }
 
+  formatarMilitar(agendamento?: Agendamento | null): string {
+    const postoGrad = agendamento?.militar?.postoGrad;
+    const nomeDeGuerra = agendamento?.militar?.nomeDeGuerra;
+
+    if (!postoGrad || !nomeDeGuerra) {
+      return 'Agendado';
+    }
+
+    return `${postoGrad} ${nomeDeGuerra}`
+      .toLowerCase()
+      .split(' ')
+      .filter(parte => parte.trim().length > 0)
+      .map(parte => parte.charAt(0).toUpperCase() + parte.slice(1))
+      .join(' ');
+  }
+
 
   desabilitarTodosOsBotoes(): boolean {
     const desabilitadoPorHorario = this.desabilitarBotoesPorHorario();


### PR DESCRIPTION
## Summary
- mostra o nome formatado do militar quando o horário está agendado na tabela semanal
- reutiliza o tooltip existente com os dados completos do agendamento e novo formatador no componente

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd531954b4832393cb92e95d5f0807