### PR TITLE
Propagar id dos agendamentos nos resumos

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/dtos/AgendamentoResumoDTO.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/dtos/AgendamentoResumoDTO.java
@@ -8,12 +8,14 @@ import lombok.Data;
 
 @Data
 public class AgendamentoResumoDTO {
+    private Long id;
     private LocalDate dia;
     private LocalTime hora;
     private String categoria;
     private MilitarResumo militar;
 
     public AgendamentoResumoDTO(Agendamento agendamento) {
+        this.id = agendamento.getId();
         this.dia = agendamento.getData();
         this.hora = agendamento.getHora();
         this.categoria = agendamento.getCategoria();

--- a/frontend/src/app/models/agendamento-resumo.ts
+++ b/frontend/src/app/models/agendamento-resumo.ts
@@ -4,6 +4,7 @@ export interface AgendamentoResumoMilitar {
 }
 
 export interface AgendamentoResumo {
+  id: number;
   dia: string;
   hora: string;
   categoria: string;

--- a/frontend/src/app/services/agendamento.service.ts
+++ b/frontend/src/app/services/agendamento.service.ts
@@ -141,6 +141,7 @@ export class AgendamentoService {
       : null;
 
     return {
+      id: resumo.id,
       data: diaIso,
       hora: horaNormalizada,
       diaSemana,


### PR DESCRIPTION
## Summary
- incluir o identificador do agendamento em AgendamentoResumoDTO e expor o valor no frontend
- repassar o id nos mapeamentos de resumo para agendamento para manter a referência durante cancelamentos

## Testing
- CI=1 npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68dd86c746e483238084132d7044f574