### PR TITLE
Ensure cancel requests include auth header

### DIFF
--- a/frontend/src/app/services/agendamento.service.ts
+++ b/frontend/src/app/services/agendamento.service.ts
@@ -102,7 +102,8 @@ export class AgendamentoService {
   
 
   cancelarAgendamento(id: number): Observable<void> {
-    return this.http.put<void>(`${this.apiUrl}/${id}/cancelar`, {}).pipe(
+    const headers = this.getAuthHeaders();
+    return this.http.put<void>(`${this.apiUrl}/${id}/cancelar`, {}, { headers }).pipe(
       tap(() => this.agendamentoAtualizadoSource.next()),
       catchError(error => throwError(() => error))
     );


### PR DESCRIPTION
## Summary
- include the authorization header when calling the cancel endpoint
- allow authenticated users to successfully cancel their own appointments after login

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd72a9c50c832388739ec32165598d