### PR TITLE
Adjust cancellation window to 30 minutes

### DIFF
--- a/frontend/src/app/components/agendamento/tabela-semanal/tabela-semanal.component.ts
+++ b/frontend/src/app/components/agendamento/tabela-semanal/tabela-semanal.component.ts
@@ -1261,7 +1261,7 @@ export class TabelaSemanalComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     const diffMinutos = (dataAgendamento.getTime() - agora.getTime()) / 60000;
-    return diffMinutos >= 15;
+    return diffMinutos >= ANTECEDENCIA_PADRAO_MINUTOS;
   }
 
   abrirModalAgendamento(agendamento: Agendamento): void {


### PR DESCRIPTION
## Summary
- require a 30-minute remaining window before allowing a scheduled appointment to be cancelled
- reuse the standard lead time constant to enforce the cancellation restriction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de73db509c8323a57aee812b1058a5