### PR TITLE
Restore 15-minute cancellation threshold for user bookings

### DIFF
--- a/frontend/src/app/pages/horarios/horarios.component.html
+++ b/frontend/src/app/pages/horarios/horarios.component.html
@@ -130,7 +130,7 @@
               <ng-container *ngIf="getAgendamentoParaDiaHora(dia, horario) as agendamento; else usuarioDisponibilidade">
                 <button mat-raised-button
                         class="botao-hora-agendado"
-                        [disabled]="!(isAgendamentoDoMilitarLogado(agendamento) && isAgendamentoDesmarcavel(agendamento))"
+                        [disabled]="!isAgendamentoDoMilitarLogado(agendamento)"
                         (click)="handleClick(agendamento)">
                   {{ formatarMilitar(agendamento) }}
                 </button>


### PR DESCRIPTION
## Summary
- revert the cancellation buffer to 15 minutes for schedule entries
- keep the cancel button active for the owning user while showing feedback when inside the cutoff

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68de7453396c83238b25dc09e7052e7a