### PR TITLE
Ensure appointment availability checks ignore cancelled statuses

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
@@ -22,13 +22,19 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
             @Param("categoria") String categoria
     );
 
-    @Query("SELECT COUNT(a) > 0 FROM Agendamento a WHERE a.data = :data AND a.hora = :hora AND a.diaSemana = :diaSemana AND a.categoria = :categoria AND a.status <> :status")
-    boolean existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(
+    @Query("""
+            SELECT COUNT(a) > 0 FROM Agendamento a
+            WHERE a.data = :data
+              AND a.hora = :hora
+              AND a.diaSemana = :diaSemana
+              AND a.categoria = :categoria
+              AND a.status NOT IN ('CANCELADO', 'ADMIN_CANCELADO')
+            """)
+    boolean existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(
             @Param("data") LocalDate data,
             @Param("hora") LocalTime hora,
             @Param("diaSemana") String diaSemana,
-            @Param("categoria") String categoria,
-            @Param("status") String status
+            @Param("categoria") String categoria
     );
 
     @Query("SELECT a FROM Agendamento a JOIN FETCH a.militar WHERE a.data = :data AND a.hora = :hora AND a.diaSemana = :diaSemana AND a.categoria = :categoria")

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/AgendamentoService.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/AgendamentoService.java
@@ -100,12 +100,11 @@ public class AgendamentoService {
             throw new IllegalStateException("Horário indisponível");
         }
 
-        boolean ocupado = agendamentoRepository.existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(
+        boolean ocupado = agendamentoRepository.existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(
             agendamento.getData(),
             agendamento.getHora(),
             dia,
-            agendamento.getCategoria(),
-            "CANCELADO"
+            agendamento.getCategoria()
         );
         if (ocupado) {
             throw new IllegalStateException("Horário indisponível");
@@ -182,10 +181,10 @@ public class AgendamentoService {
     }
 
     public boolean isAgendamentoDisponivel(LocalDate data, LocalTime hora, String diaSemana, String categoria) {
-        // Considera apenas agendamentos cujo status seja diferente de 'CANCELADO'
+        // Considera apenas agendamentos ativos (desconsiderando cancelamentos pelo usuário ou admin)
         String dia = DiaSemana.from(diaSemana).getValor();
-        return !agendamentoRepository.existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(
-                data, hora, dia, categoria, "CANCELADO");
+        return !agendamentoRepository.existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(
+                data, hora, dia, categoria);
     }
 
     public Optional<Agendamento> findAgendamentoByDataHoraDiaCategoria(
@@ -210,12 +209,11 @@ public class AgendamentoService {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "O horário selecionado já está ocupado ou indisponível.");
         }
 
-        boolean ocupado = agendamentoRepository.existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(
+        boolean ocupado = agendamentoRepository.existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(
             data,
             hora,
             dia,
-            categoria,
-            "CANCELADO"
+            categoria
         );
         if (ocupado) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "O horário selecionado já está ocupado para esta data.");
@@ -223,12 +221,11 @@ public class AgendamentoService {
     }
 
     public void checarDuplicidade(LocalDate data, LocalTime hora, String dia, String categoria) {
-        boolean jaExiste = agendamentoRepository.existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(
+        boolean jaExiste = agendamentoRepository.existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(
             data,
             hora,
             dia,
-            categoria,
-            "CANCELADO"
+            categoria
         );
 
         if (jaExiste) {

--- a/backend/src/test/java/intraer/ccabr/barbearia_api/services/AgendamentoServiceTest.java
+++ b/backend/src/test/java/intraer/ccabr/barbearia_api/services/AgendamentoServiceTest.java
@@ -65,7 +65,7 @@ class AgendamentoServiceTest {
 
         when(horarioRepository.findByDiaAndHorarioAndCategoria(dia, hora, categoria))
                 .thenReturn(Optional.of(horario));
-        when(agendamentoRepository.existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(data, hora, dia, categoria, "CANCELADO"))
+        when(agendamentoRepository.existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(data, hora, dia, categoria))
                 .thenReturn(false);
 
         Agendamento resultado = agendamentoService.criarAgendamentoTransactional(agendamento);
@@ -113,7 +113,7 @@ class AgendamentoServiceTest {
 
         when(horarioRepository.findByDiaAndHorarioAndCategoria(dia, hora, categoria))
                 .thenReturn(Optional.of(horario));
-        when(agendamentoRepository.existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(data, hora, dia, categoria, "CANCELADO"))
+        when(agendamentoRepository.existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(data, hora, dia, categoria))
                 .thenReturn(true);
 
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
@@ -133,11 +133,11 @@ class AgendamentoServiceTest {
 
         when(horarioRepository.findByDiaAndHorarioAndCategoria(dia, hora, categoria))
                 .thenReturn(Optional.of(horario));
-        when(agendamentoRepository.existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(data, hora, dia, categoria, "CANCELADO"))
+        when(agendamentoRepository.existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(data, hora, dia, categoria))
                 .thenReturn(false);
 
         assertDoesNotThrow(() -> agendamentoService.verificarHorarioDisponivel(data, dia, hora, categoria));
-        verify(agendamentoRepository).existsByDataAndHoraAndDiaSemanaAndCategoriaAndStatusNot(data, hora, dia, categoria, "CANCELADO");
+        verify(agendamentoRepository).existsAtivoByDataAndHoraAndDiaSemanaAndCategoria(data, hora, dia, categoria);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a repository query that returns only active appointments for a given slot
- update availability validations to rely on the active-only lookup
- adjust service unit tests to reflect the new repository method

## Testing
- mvn test -q

------
https://chatgpt.com/codex/tasks/task_e_68de79fb1be08323800849317c576af6