### PR TITLE
Prevent past appointments from blocking weekly schedule availability

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
@@ -94,7 +94,14 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
     @Query("DELETE FROM Agendamento a WHERE a.hora = :hora")
     void deleteByHora(@Param("hora") LocalTime hora);
 
-    @Query("SELECT COUNT(a) > 0 FROM Agendamento a WHERE a.hora = :hora AND a.diaSemana = :diaSemana AND a.categoria = :categoria AND a.status = 'AGENDADO'")
+    @Query("""
+            SELECT COUNT(a) > 0 FROM Agendamento a
+            WHERE a.hora = :hora
+              AND a.diaSemana = :diaSemana
+              AND a.categoria = :categoria
+              AND a.status = 'AGENDADO'
+              AND a.data >= CURRENT_DATE
+            """)
     boolean existsByHoraAndDiaSemanaAndCategoria(
             @Param("hora") LocalTime hora,
             @Param("diaSemana") String diaSemana,


### PR DESCRIPTION
## Summary
- avoid keeping weekly slots locked by ensuring active appointment checks ignore past dates

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e3f27178908323b62b519fea9665b6