### PR TITLE
Reset weekly schedules each Monday

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
@@ -168,6 +168,17 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
     );
 
     @Query("""
+            SELECT a FROM Agendamento a
+            JOIN FETCH a.militar
+            WHERE a.data BETWEEN :inicio AND :fim
+              AND a.status NOT IN ('CANCELADO', 'ADMIN_CANCELADO')
+            """)
+    List<Agendamento> findAtivosNoPeriodo(
+            @Param("inicio") LocalDate inicio,
+            @Param("fim") LocalDate fim
+    );
+
+    @Query("""
             SELECT COUNT(a) > 0 FROM Agendamento a
             WHERE a.categoria = :categoria
               AND ((a.status = 'AGENDADO' AND a.data >= :dataAtual)

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/HorarioDisponibilidadeScheduler.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/HorarioDisponibilidadeScheduler.java
@@ -1,63 +1,28 @@
 package intraer.ccabr.barbearia_api.services;
 
-import intraer.ccabr.barbearia_api.enums.HorarioStatus;
-import intraer.ccabr.barbearia_api.models.Horario;
-import intraer.ccabr.barbearia_api.repositories.AgendamentoRepository;
-import intraer.ccabr.barbearia_api.repositories.HorarioRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 public class HorarioDisponibilidadeScheduler {
 
     private static final Logger logger = LoggerFactory.getLogger(HorarioDisponibilidadeScheduler.class);
 
-    private final HorarioRepository horarioRepository;
-    private final AgendamentoRepository agendamentoRepository;
+    private final HorarioService horarioService;
 
-    public HorarioDisponibilidadeScheduler(HorarioRepository horarioRepository,
-                                           AgendamentoRepository agendamentoRepository) {
-        this.horarioRepository = horarioRepository;
-        this.agendamentoRepository = agendamentoRepository;
+    public HorarioDisponibilidadeScheduler(HorarioService horarioService) {
+        this.horarioService = horarioService;
     }
 
     @Scheduled(cron = "0 0 0 * * MON")
-    @Transactional
     public void resetarDisponibilidadeSemanal() {
-        List<Horario> horarios = horarioRepository.findAll();
-        if (horarios.isEmpty()) {
-            logger.info("Nenhum horário cadastrado para reset semanal de disponibilidade.");
-            return;
-        }
-
-        int atualizados = 0;
-        for (Horario horario : horarios) {
-            boolean possuiAgendamentoAtivo = agendamentoRepository.existsByHoraAndDiaSemanaAndCategoria(
-                    horario.getHorario(),
-                    horario.getDia(),
-                    horario.getCategoria()
-            );
-
-            HorarioStatus statusEsperado = possuiAgendamentoAtivo
-                    ? HorarioStatus.AGENDADO
-                    : HorarioStatus.DISPONIVEL;
-
-            if (horario.getStatus() != statusEsperado) {
-                horario.setStatus(statusEsperado);
-                atualizados++;
-            }
-        }
-
+        int atualizados = horarioService.ajustarStatusHorariosSemanaAtual();
         if (atualizados > 0) {
-            horarioRepository.saveAll(horarios);
-            logger.info("Reset semanal concluído. {} de {} horários tiveram a disponibilidade ajustada.", atualizados, horarios.size());
+            logger.info("Reset semanal concluído. {} horários tiveram a disponibilidade ajustada.", atualizados);
         } else {
-            logger.info("Reset semanal executado. Nenhuma atualização necessária entre {} horários avaliados.", horarios.size());
+            logger.info("Reset semanal executado. Nenhuma atualização necessária.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add repository query to load weekly appointments and reuse them across services
- update HorarioService to normalise weekly availability, refresh DTO data, and reuse the logic in the scheduler
- simplify the scheduler to delegate weekly resets to the service logic

## Testing
- ./mvnw -q test

------
https://chatgpt.com/codex/tasks/task_e_68e410597ec0832390767d922d663a87