### PR TITLE
Atualiza controle de bloqueio baseado em U_Agendamento

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/models/Militar.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/models/Militar.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -83,6 +84,10 @@ public class Militar implements UserDetails {
     @Column(name = "quadro", length = 15)
     @JsonProperty
     private String quadro;
+
+    @Column(name = "U_Agendamento")
+    @JsonProperty
+    private LocalDate ultimoAgendamento;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "categoria", length = 10)

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
@@ -48,21 +48,6 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
     List<Agendamento> findByStatus(String status);
 
 
-    @Query("""
-            SELECT a.militar, MAX(a.data)
-            FROM Agendamento a
-            WHERE a.status IN ('AGENDADO', 'REALIZADO')
-              AND a.data <= :hoje
-            GROUP BY a.militar
-            HAVING MAX(a.data) > :limite
-            ORDER BY MAX(a.data) DESC
-            """)
-    List<Object[]> findMilitaresBloqueados15Dias(
-            @Param("hoje") LocalDate hoje,
-            @Param("limite") LocalDate limite
-    );
-
-
     @Query("SELECT a FROM Agendamento a WHERE a.militar.saram = :saram AND a.status IN ('AGENDADO', 'REALIZADO') ORDER BY a.data DESC")
     Optional<Agendamento> findUltimoAgendamentoBySaram(@Param("saram") String saram);
 

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/MilitarRepository.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/MilitarRepository.java
@@ -3,6 +3,7 @@ package intraer.ccabr.barbearia_api.repositories;
 import intraer.ccabr.barbearia_api.models.Militar;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,4 +38,6 @@ public interface MilitarRepository extends JpaRepository<Militar, Long> {
      */
     @Query("SELECT m FROM Militar m WHERE LOWER(m.quadro) = LOWER(:quadro)")
     List<Militar> findByQuadro(String quadro);
+
+    List<Militar> findByUltimoAgendamentoAfter(LocalDate limite);
 }


### PR DESCRIPTION
## Summary
- adiciona o campo U_Agendamento à entidade de militar para armazenar a última data agendada
- atualiza o serviço de agendamentos para popular o campo e utilizar o novo dado na regra de 15 dias e na listagem de bloqueados
- ajusta os repositórios para consultar militares bloqueados a partir da nova coluna

## Testing
- `./mvnw test`


------
https://chatgpt.com/codex/tasks/task_e_68e41649eaa083239bc287921cb3f986