### PR TITLE
Ensure tooltip justification returns string

### DIFF
--- a/frontend/src/app/pages/meus-agendamentos/meus-agendamentos.component.ts
+++ b/frontend/src/app/pages/meus-agendamentos/meus-agendamentos.component.ts
@@ -173,10 +173,10 @@ export class MeusAgendamentosComponent implements OnInit, AfterViewInit {
     return mapa[justificativa.status] ?? '';
   }
 
-  tooltipJustificativa(agendamento: Agendamento): string | null {
+  tooltipJustificativa(agendamento: Agendamento): string {
     const justificativa = agendamento.justificativaAusencia;
     if (!justificativa) {
-      return null;
+      return '';
     }
 
     if (justificativa.status === 'AGUARDANDO') {
@@ -190,7 +190,7 @@ export class MeusAgendamentosComponent implements OnInit, AfterViewInit {
       .filter(Boolean)
       .join(' ');
     if (!avaliador) {
-      return null;
+      return '';
     }
 
     const textoBase = justificativa.status === 'APROVADO' ? 'Aprovado' : 'Recusado';


### PR DESCRIPTION
## Summary
- update tooltipJustificativa to always return a string for matTooltip bindings
- fall back to an empty tooltip when no justification details are available

## Testing
- npm run lint *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e5011e1a708323b9dc420e1c3909b4