### PR TITLE
Add admin absence filters and update approvals

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
@@ -48,14 +48,14 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
     List<Agendamento> findByStatus(String status);
 
 
-    @Query("SELECT a FROM Agendamento a WHERE a.militar.saram = :saram AND a.status IN ('AGENDADO', 'REALIZADO') ORDER BY a.data DESC")
+    @Query("SELECT a FROM Agendamento a WHERE a.militar.saram = :saram AND a.status IN ('AGENDADO', 'REALIZADO', 'REAGENDADO') ORDER BY a.data DESC")
     Optional<Agendamento> findUltimoAgendamentoBySaram(@Param("saram") String saram);
 
     @Query("""
             SELECT a FROM Agendamento a
             JOIN FETCH a.militar
             WHERE a.militar.id = :militarId
-              AND a.status IN ('AGENDADO', 'REALIZADO')
+              AND a.status IN ('AGENDADO', 'REALIZADO', 'REAGENDADO')
             ORDER BY a.data DESC
             """)
     Optional<Agendamento> findUltimoAgendamentoAtivoByMilitarId(@Param("militarId") Long militarId);
@@ -111,13 +111,13 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
                             @Param("diaSemana") String diaSemana,
                             @Param("categoria") String categoria);
 
-    @Query("SELECT COUNT(a) FROM Agendamento a WHERE a.data = :data AND a.status IN ('AGENDADO', 'REALIZADO')")
+    @Query("SELECT COUNT(a) FROM Agendamento a WHERE a.data = :data AND a.status IN ('AGENDADO', 'REALIZADO', 'REAGENDADO')")
     long countByData(@Param("data") LocalDate data);
 
-    @Query("SELECT a.categoria, COUNT(a) FROM Agendamento a WHERE a.data = :data AND a.status IN ('AGENDADO', 'REALIZADO') GROUP BY a.categoria")
+    @Query("SELECT a.categoria, COUNT(a) FROM Agendamento a WHERE a.data = :data AND a.status IN ('AGENDADO', 'REALIZADO', 'REAGENDADO') GROUP BY a.categoria")
     List<Object[]> countByCategoria(@Param("data") LocalDate data);
 
-    @Query("SELECT a.data, COUNT(a) FROM Agendamento a WHERE a.data >= :startDate AND a.status IN ('AGENDADO', 'REALIZADO') GROUP BY a.data ORDER BY a.data")
+    @Query("SELECT a.data, COUNT(a) FROM Agendamento a WHERE a.data >= :startDate AND a.status IN ('AGENDADO', 'REALIZADO', 'REAGENDADO') GROUP BY a.data ORDER BY a.data")
     List<Object[]> countByDataSince(@Param("startDate") LocalDate startDate);
 
     List<Agendamento> findTop5ByStatusOrderByDataDescHoraDesc(String status);
@@ -167,7 +167,7 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
             SELECT COUNT(a) > 0 FROM Agendamento a
             WHERE a.categoria = :categoria
               AND ((a.status = 'AGENDADO' AND a.data >= :dataAtual)
-                OR (a.status = 'REALIZADO' AND a.data <= :dataAtual))
+                OR (a.status IN ('REALIZADO', 'REAGENDADO') AND a.data <= :dataAtual))
               AND (a.hora < :inicio OR a.hora > :fim)
             """)
     boolean existsAtivoForaJanela(@Param("inicio") LocalTime inicio,

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/JustificativaAusenciaService.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/JustificativaAusenciaService.java
@@ -26,13 +26,16 @@ public class JustificativaAusenciaService {
     private final JustificativaAusenciaRepository repository;
     private final AgendamentoRepository agendamentoRepository;
     private final MilitarRepository militarRepository;
+    private final AgendamentoService agendamentoService;
 
     public JustificativaAusenciaService(JustificativaAusenciaRepository repository,
                                         AgendamentoRepository agendamentoRepository,
-                                        MilitarRepository militarRepository) {
+                                        MilitarRepository militarRepository,
+                                        AgendamentoService agendamentoService) {
         this.repository = repository;
         this.agendamentoRepository = agendamentoRepository;
         this.militarRepository = militarRepository;
+        this.agendamentoService = agendamentoService;
     }
 
     @Transactional
@@ -104,6 +107,13 @@ public class JustificativaAusenciaService {
         justificativa.setDataResposta(LocalDateTime.now());
         justificativa.setAvaliadoPorPostoGrad(admin.getPostoGrad());
         justificativa.setAvaliadoPorNomeGuerra(admin.getNomeDeGuerra());
+
+        Agendamento agendamento = justificativa.getAgendamento();
+        if (agendamento != null) {
+            agendamento.setStatus("REAGENDADO");
+            agendamentoService.marcarHorarioComoIndisponivel(agendamento);
+            agendamentoRepository.save(agendamento);
+        }
 
         Militar militar = justificativa.getMilitar();
         militar.setUltimoAgendamento(LocalDate.now());

--- a/backend/src/main/resources/db/migration/V11__add_reagendado_status.sql
+++ b/backend/src/main/resources/db/migration/V11__add_reagendado_status.sql
@@ -1,0 +1,6 @@
+ALTER TABLE agendamentos
+    DROP CONSTRAINT IF EXISTS ck_agendamento_status;
+
+ALTER TABLE agendamentos
+    ADD CONSTRAINT ck_agendamento_status
+    CHECK (status IN ('AGENDADO','REALIZADO','REAGENDADO','CANCELADO','ADMIN_CANCELADO'));

--- a/frontend/src/app/components/agendamento/tabela-semanal/tabela-semanal.component.css
+++ b/frontend/src/app/components/agendamento/tabela-semanal/tabela-semanal.component.css
@@ -94,6 +94,13 @@
   cursor: not-allowed;
 }
 
+.tabela-botao-reagendado {
+  width: 100%;
+  background-color: #0288d1 !important;
+  color: #fff !important;
+  border: 1px solid #01579b !important;
+}
+
 .feedback-message {
   color: red;
   text-align: center;
@@ -150,6 +157,10 @@
 
 .status-indisponivel {
   color: #9e9e9e;
+}
+
+.status-reagendado {
+  color: #0288d1;
 }
 
 .tabela-loading-card {

--- a/frontend/src/app/pages/admin-ausencias/admin-ausencias.component.css
+++ b/frontend/src/app/pages/admin-ausencias/admin-ausencias.component.css
@@ -1,3 +1,30 @@
+.filtros {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+  align-items: flex-end;
+}
+
+.filtros .campo {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.filtros .campo-data {
+  max-width: 220px;
+}
+
+.filtros .campo-status {
+  min-width: 200px;
+}
+
+.botao-limpar {
+  align-self: center;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
 .ausencias-wrapper {
   display: flex;
   gap: 24px;
@@ -74,6 +101,14 @@
 @media (max-width: 1024px) {
   .ausencias-wrapper {
     flex-direction: column;
+  }
+
+  .filtros {
+    align-items: stretch;
+  }
+
+  .botao-limpar {
+    align-self: flex-start;
   }
 
   .lista {

--- a/frontend/src/app/pages/admin-ausencias/admin-ausencias.component.html
+++ b/frontend/src/app/pages/admin-ausencias/admin-ausencias.component.html
@@ -1,36 +1,129 @@
 <app-admin-navbar [containerClass]="'ausencias-container'" [contentClass]="'ausencias-content'">
+  <div class="filtros" *ngIf="!carregando">
+    <mat-form-field appearance="outline" class="campo campo-texto">
+      <mat-label>Buscar por posto ou nome</mat-label>
+      <input
+        matInput
+        placeholder="Ex.: Sgt Silva"
+        [(ngModel)]="filtroTexto"
+        (ngModelChange)="aplicarFiltros()"
+      />
+      <button
+        *ngIf="filtroTexto"
+        mat-icon-button
+        matSuffix
+        aria-label="Limpar busca"
+        (click)="limparCampo('texto')"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="campo campo-data">
+      <mat-label>Data inicial</mat-label>
+      <input
+        matInput
+        [matDatepicker]="dataInicioPicker"
+        [(ngModel)]="filtroDataInicio"
+        (dateChange)="aplicarFiltros()"
+      />
+      <mat-datepicker-toggle matSuffix [for]="dataInicioPicker"></mat-datepicker-toggle>
+      <button
+        *ngIf="filtroDataInicio"
+        mat-icon-button
+        matSuffix
+        aria-label="Limpar data inicial"
+        (click)="limparCampo('dataInicio')"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+      <mat-datepicker #dataInicioPicker></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="campo campo-data">
+      <mat-label>Data final</mat-label>
+      <input
+        matInput
+        [matDatepicker]="dataFimPicker"
+        [(ngModel)]="filtroDataFim"
+        (dateChange)="aplicarFiltros()"
+      />
+      <mat-datepicker-toggle matSuffix [for]="dataFimPicker"></mat-datepicker-toggle>
+      <button
+        *ngIf="filtroDataFim"
+        mat-icon-button
+        matSuffix
+        aria-label="Limpar data final"
+        (click)="limparCampo('dataFim')"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+      <mat-datepicker #dataFimPicker></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="campo campo-status">
+      <mat-label>Status</mat-label>
+      <mat-select multiple [(ngModel)]="filtroStatus" (selectionChange)="aplicarFiltros()">
+        <mat-option *ngFor="let status of statusOptions" [value]="status.value">
+          {{ status.label }}
+        </mat-option>
+      </mat-select>
+      <button
+        *ngIf="filtroStatus.length"
+        mat-icon-button
+        matSuffix
+        aria-label="Limpar status selecionados"
+        (click)="limparCampo('status')"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-form-field>
+
+    <button
+      mat-stroked-button
+      color="primary"
+      class="botao-limpar"
+      (click)="limparFiltros()"
+      [disabled]="!temFiltros()"
+    >
+      Limpar filtros
+    </button>
+  </div>
+
   <div class="ausencias-wrapper" *ngIf="!carregando; else loading">
     <ng-container *ngIf="solicitacoes.length; else vazio">
-      <div class="lista">
-        <mat-nav-list>
-          <a
-            mat-list-item
-            *ngFor="let solicitacao of solicitacoes"
-            (click)="selecionar(solicitacao)"
-            [class.selecionado]="selecionada?.id === solicitacao.id"
-          >
-            <div matLine>{{ tituloSolicitacao(solicitacao) }}</div>
-            <div matLine class="status" [ngClass]="classeStatus(solicitacao.status)">
-              {{ descricaoStatus(solicitacao) }}
-            </div>
-          </a>
-        </mat-nav-list>
-      </div>
-      <div class="detalhe" *ngIf="selecionada; else selecione">
-        <h2>Justificativa</h2>
-        <p class="texto-justificativa">{{ selecionada?.justificativa }}</p>
-        <div class="status-detalhe" [ngClass]="classeStatus(selecionada!.status)">
-          Status: {{ descricaoStatus(selecionada!) }}
+      <ng-container *ngIf="solicitacoesFiltradas.length; else semResultados">
+        <div class="lista">
+          <mat-nav-list>
+            <a
+              mat-list-item
+              *ngFor="let solicitacao of solicitacoesFiltradas"
+              (click)="selecionar(solicitacao)"
+              [class.selecionado]="selecionada?.id === solicitacao.id"
+            >
+              <div matLine>{{ tituloSolicitacao(solicitacao) }}</div>
+              <div matLine class="status" [ngClass]="classeStatus(solicitacao.status)">
+                {{ descricaoStatus(solicitacao) }}
+              </div>
+            </a>
+          </mat-nav-list>
         </div>
-        <div class="acoes" *ngIf="selecionada?.status === 'AGUARDANDO'">
-          <button mat-raised-button color="primary" (click)="aprovarSelecionada()">
-            Aprovar
-          </button>
-          <button mat-stroked-button color="warn" (click)="recusarSelecionada()">
-            Recusar
-          </button>
+        <div class="detalhe" *ngIf="selecionada; else selecione">
+          <h2>Justificativa</h2>
+          <p class="texto-justificativa">{{ selecionada?.justificativa }}</p>
+          <div class="status-detalhe" [ngClass]="classeStatus(selecionada!.status)">
+            Status: {{ descricaoStatus(selecionada!) }}
+          </div>
+          <div class="acoes" *ngIf="selecionada?.status === 'AGUARDANDO'">
+            <button mat-raised-button color="primary" (click)="aprovarSelecionada()">
+              Aprovar
+            </button>
+            <button mat-stroked-button color="warn" (click)="recusarSelecionada()">
+              Recusar
+            </button>
+          </div>
         </div>
-      </div>
+      </ng-container>
     </ng-container>
   </div>
 </app-admin-navbar>
@@ -45,6 +138,15 @@
 <ng-template #vazio>
   <div class="estado">
     <p>Nenhuma justificativa de ausência no momento.</p>
+  </div>
+</ng-template>
+
+<ng-template #semResultados>
+  <div class="estado">
+    <p>Nenhuma justificativa encontrada com os filtros selecionados.</p>
+    <button mat-stroked-button color="primary" (click)="limparFiltros()" [disabled]="!temFiltros()">
+      Limpar filtros
+    </button>
   </div>
 </ng-template>
 

--- a/frontend/src/app/pages/admin-ausencias/admin-ausencias.component.ts
+++ b/frontend/src/app/pages/admin-ausencias/admin-ausencias.component.ts
@@ -15,9 +15,19 @@ import { LoggingService } from '../../services/logging.service';
 })
 export class AdminAusenciasComponent implements OnInit {
   solicitacoes: JustificativaAusenciaAdmin[] = [];
+  solicitacoesFiltradas: JustificativaAusenciaAdmin[] = [];
   selecionada?: JustificativaAusenciaAdmin;
   carregando = false;
   erroCarregamento = false;
+  filtroTexto = '';
+  filtroDataInicio: Date | null = null;
+  filtroDataFim: Date | null = null;
+  filtroStatus: JustificativaStatus[] = [];
+  readonly statusOptions: { value: JustificativaStatus; label: string }[] = [
+    { value: 'AGUARDANDO', label: 'Aguardando' },
+    { value: 'APROVADO', label: 'Aprovado' },
+    { value: 'RECUSADO', label: 'Negado' }
+  ];
 
   constructor(
     private justificativaService: JustificativaAusenciaService,
@@ -35,7 +45,7 @@ export class AdminAusenciasComponent implements OnInit {
     this.justificativaService.listarAdmin().subscribe({
       next: solicitacoes => {
         this.solicitacoes = solicitacoes;
-        this.selecionada = solicitacoes[0];
+        this.aplicarFiltros();
         this.carregando = false;
       },
       error: erro => {
@@ -53,6 +63,80 @@ export class AdminAusenciasComponent implements OnInit {
     this.selecionada = solicitacao;
   }
 
+  aplicarFiltros(): void {
+    let filtradas = [...this.solicitacoes];
+
+    if (this.filtroTexto.trim()) {
+      const termo = this.filtroTexto.trim().toLowerCase();
+      filtradas = filtradas.filter(item => {
+        const posto = (item.postoGradMilitar || '').toLowerCase();
+        const nome = (item.nomeDeGuerraMilitar || '').toLowerCase();
+        return posto.includes(termo) || nome.includes(termo);
+      });
+    }
+
+    const inicio = this.normalizarInicio(this.filtroDataInicio);
+    const fim = this.normalizarFim(this.filtroDataFim);
+    if (inicio || fim) {
+      const [dataInicio, dataFim] = this.ordenarDatas(inicio, fim);
+      filtradas = filtradas.filter(item => {
+        const data = this.converterParaDate(item.data);
+        if (!data) {
+          return false;
+        }
+        return (!dataInicio || data >= dataInicio) && (!dataFim || data <= dataFim);
+      });
+    }
+
+    if (this.filtroStatus.length) {
+      const filtroSet = new Set(this.filtroStatus);
+      filtradas = filtradas.filter(item => filtroSet.has(item.status));
+    }
+
+    this.solicitacoesFiltradas = filtradas;
+
+    if (!filtradas.length) {
+      this.selecionada = undefined;
+      return;
+    }
+
+    if (!this.selecionada || !filtradas.some(item => item.id === this.selecionada?.id)) {
+      this.selecionada = filtradas[0];
+    } else {
+      this.selecionada = filtradas.find(item => item.id === this.selecionada?.id);
+    }
+  }
+
+  limparCampo(campo: 'texto' | 'dataInicio' | 'dataFim' | 'status'): void {
+    if (campo === 'texto') {
+      this.filtroTexto = '';
+    } else if (campo === 'dataInicio') {
+      this.filtroDataInicio = null;
+    } else if (campo === 'dataFim') {
+      this.filtroDataFim = null;
+    } else if (campo === 'status') {
+      this.filtroStatus = [];
+    }
+    this.aplicarFiltros();
+  }
+
+  limparFiltros(): void {
+    this.filtroTexto = '';
+    this.filtroDataInicio = null;
+    this.filtroDataFim = null;
+    this.filtroStatus = [];
+    this.aplicarFiltros();
+  }
+
+  temFiltros(): boolean {
+    return (
+      !!this.filtroTexto.trim() ||
+      !!this.filtroDataInicio ||
+      !!this.filtroDataFim ||
+      this.filtroStatus.length > 0
+    );
+  }
+
   tituloSolicitacao(solicitacao: JustificativaAusenciaAdmin): string {
     const posto = solicitacao.postoGradMilitar ?? '';
     const nome = solicitacao.nomeDeGuerraMilitar ?? '';
@@ -62,8 +146,9 @@ export class AdminAusenciasComponent implements OnInit {
   }
 
   descricaoStatus(solicitacao: JustificativaAusenciaAdmin): string {
+    const statusBase = solicitacao.status === 'RECUSADO' ? 'NEGADO' : solicitacao.status;
     if (solicitacao.status === 'AGUARDANDO') {
-      return 'AGUARDANDO';
+      return statusBase;
     }
     const avaliador = [
       solicitacao.avaliadoPorPostoGrad,
@@ -72,9 +157,9 @@ export class AdminAusenciasComponent implements OnInit {
       .filter(Boolean)
       .join(' ');
     if (!avaliador) {
-      return solicitacao.status;
+      return statusBase;
     }
-    return `${solicitacao.status} por ${avaliador}`;
+    return `${statusBase} por ${avaliador}`;
   }
 
   classeStatus(status: JustificativaStatus): string {
@@ -124,5 +209,50 @@ export class AdminAusenciasComponent implements OnInit {
     );
     const novaSelecionada = this.solicitacoes.find(item => item.id === atualizada.id);
     this.selecionada = novaSelecionada ?? this.selecionada;
+    this.aplicarFiltros();
+  }
+
+  private converterParaDate(data?: string): Date | null {
+    if (!data) {
+      return null;
+    }
+    const partes = data.split('/').map(Number);
+    if (partes.length !== 3) {
+      return null;
+    }
+    const [dia, mes, ano] = partes;
+    if (!dia || !mes || !ano) {
+      return null;
+    }
+    const resultado = new Date(ano, mes - 1, dia, 12);
+    return Number.isNaN(resultado.getTime()) ? null : resultado;
+  }
+
+  private normalizarInicio(data: Date | null): Date | null {
+    if (!data) {
+      return null;
+    }
+    const inicio = new Date(data);
+    inicio.setHours(0, 0, 0, 0);
+    return inicio;
+  }
+
+  private normalizarFim(data: Date | null): Date | null {
+    if (!data) {
+      return null;
+    }
+    const fim = new Date(data);
+    fim.setHours(23, 59, 59, 999);
+    return fim;
+  }
+
+  private ordenarDatas(
+    inicio: Date | null,
+    fim: Date | null
+  ): [Date | null, Date | null] {
+    if (inicio && fim && inicio > fim) {
+      return [fim, inicio];
+    }
+    return [inicio, fim];
   }
 }

--- a/frontend/src/app/pages/gerenciar-registros/gerenciar-registros.component.css
+++ b/frontend/src/app/pages/gerenciar-registros/gerenciar-registros.component.css
@@ -69,6 +69,10 @@
   color: #4caf50;
 }
 
+.status-reagendado {
+  color: #0288d1;
+}
+
 .status-cancelado {
   color: #f44336;
 }

--- a/frontend/src/app/pages/gerenciar-registros/gerenciar-registros.component.html
+++ b/frontend/src/app/pages/gerenciar-registros/gerenciar-registros.component.html
@@ -65,6 +65,7 @@
       >
         <mat-button-toggle value="AGENDADO">Agendado</mat-button-toggle>
         <mat-button-toggle value="REALIZADO">Efetuado</mat-button-toggle>
+        <mat-button-toggle value="REAGENDADO">Reagendado</mat-button-toggle>
         <mat-button-toggle value="CANCELADO">Cancelado</mat-button-toggle>
       </mat-button-toggle-group>
       <div class="acoes">

--- a/frontend/src/app/pages/meus-agendamentos/meus-agendamentos.component.css
+++ b/frontend/src/app/pages/meus-agendamentos/meus-agendamentos.component.css
@@ -61,6 +61,10 @@
   color: #9e9e9e;
 }
 
+.status-reagendado {
+  color: #0288d1;
+}
+
 .btn-justificativa {
   min-width: 170px;
 }

--- a/frontend/src/app/pipes/status-format.pipe.ts
+++ b/frontend/src/app/pipes/status-format.pipe.ts
@@ -9,6 +9,7 @@ export class StatusFormatPipe implements PipeTransform {
     INDISPONIVEL: 'Indisponível',
     AGENDADO: 'Agendado',
     REALIZADO: 'Efetuado',
+    REAGENDADO: 'Reagendado',
     CANCELADO: 'Cancelado',
     ADMIN_CANCELADO: 'Cancelado'
   };
@@ -18,6 +19,7 @@ export class StatusFormatPipe implements PipeTransform {
     DISPONIVEL: 'status-disponivel',
     INDISPONIVEL: 'status-indisponivel',
     REALIZADO: 'status-realizado',
+    REAGENDADO: 'status-reagendado',
     CANCELADO: 'status-cancelado',
     ADMIN_CANCELADO: 'status-cancelado'
   };
@@ -27,6 +29,7 @@ export class StatusFormatPipe implements PipeTransform {
     AGENDADO: 'botao-agendado-outro',
     INDISPONIVEL: 'tabela-botao-indisponivel',
     REALIZADO: 'tabela-botao-realizado',
+    REAGENDADO: 'tabela-botao-reagendado',
     CANCELADO: 'tabela-botao-cancelado',
     ADMIN_CANCELADO: 'tabela-botao-cancelado'
   };


### PR DESCRIPTION
## Summary
- add search, date range, and status filters to the admin ausências page while keeping the selection list in sync with filtered results
- mark approved justificativas as REAGENDADO/indisponível by updating scheduling services, repository queries, and database constraints
- extend status formatting and styling so REAGENDADO entries render consistently across dashboards and reports

## Testing
- npm run lint *(fails: ESLint config not yet migrated to eslint.config.js)*
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e519851eb083238236a5f8d3178333