### PR TITLE
Permite reagendar após justificativa aprovada

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/JustificativaAusenciaService.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/JustificativaAusenciaService.java
@@ -116,7 +116,7 @@ public class JustificativaAusenciaService {
         }
 
         Militar militar = justificativa.getMilitar();
-        militar.setUltimoAgendamento(LocalDate.now());
+        militar.setUltimoAgendamento(null);
         militarRepository.save(militar);
 
         return repository.save(justificativa);

--- a/frontend/src/app/pages/meus-agendamentos/meus-agendamentos.component.ts
+++ b/frontend/src/app/pages/meus-agendamentos/meus-agendamentos.component.ts
@@ -129,6 +129,11 @@ export class MeusAgendamentosComponent implements OnInit, AfterViewInit {
       return false;
     }
 
+    const statusPermitidos = new Set(['REALIZADO', 'EFETUADO']);
+    if (!statusPermitidos.has(status)) {
+      return false;
+    }
+
     const dataAgendamento = new Date(agendamento.data);
     if (Number.isNaN(dataAgendamento.getTime())) {
       return false;


### PR DESCRIPTION
## Summary
- remove o registro de último agendamento do militar quando a justificativa é aprovada
- mantém o agendamento anterior como reagendado e libera o usuário para marcar um novo horário

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e53515ca2c83238c72c329fab1f0ed