### PR TITLE
Ensure schedule listing recalculates availability

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/HorarioService.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/HorarioService.java
@@ -178,6 +178,8 @@ public class HorarioService {
     // }
 
     public Map<String, Map<String, List<Horario>>> getTodosHorarios() {
+        ajustarStatusHorariosSemanaAtual();
+
         ConfiguracaoAgendamento config = configuracaoAgendamentoService.buscarConfiguracao();
         Map<String, Map<String, List<Horario>>> horarios = new HashMap<>();
         String[] categorias = {"GRADUADO", "OFICIAL"};


### PR DESCRIPTION
## Summary
- call the weekly availability adjustment before returning the schedule grid so stale states from past weeks are cleared

## Testing
- ./mvnw -q test

------
https://chatgpt.com/codex/tasks/task_e_68e547c7073c8323bf5d5e1c41fd4218