### PR TITLE
Release stale weekly slots without overriding realized appointments

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/HorarioRepository.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/HorarioRepository.java
@@ -1,5 +1,6 @@
 package intraer.ccabr.barbearia_api.repositories;
 
+import intraer.ccabr.barbearia_api.enums.HorarioStatus;
 import intraer.ccabr.barbearia_api.models.Horario;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -25,6 +26,8 @@ public interface HorarioRepository extends JpaRepository<Horario, Long> {
     List<Horario> findByCategoria(String categoria);
 
     long countByDia(String dia);
+
+    List<Horario> findByStatus(HorarioStatus status);
 
     @Transactional
     @Modifying

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/HorarioService.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/HorarioService.java
@@ -177,7 +177,57 @@ public class HorarioService {
     //     logger.info("Horários base inicializados a partir do banco: {}", horariosBase);
     // }
 
+    private void liberarHorariosSemanaAtual() {
+        List<Horario> agendados = horarioRepository.findByStatus(HorarioStatus.AGENDADO);
+        if (agendados.isEmpty()) {
+            return;
+        }
+
+        LocalDate hoje = LocalDate.now();
+        LocalDate inicioSemana = calcularInicioSemana(hoje);
+        LocalDate fimSemana = inicioSemana.plusDays(4);
+
+        List<Agendamento> agendamentosSemana = agendamentoRepository.findAtivosNoPeriodo(inicioSemana, fimSemana);
+        Map<String, Map<LocalTime, Agendamento>> agendamentosAgrupados = agruparAgendamentosPorDiaCategoria(agendamentosSemana);
+
+        List<Horario> liberados = new ArrayList<>();
+
+        for (Horario horario : agendados) {
+            String chave = chaveDiaCategoria(horario.getDia(), horario.getCategoria());
+            Map<LocalTime, Agendamento> agendadosDia = agendamentosAgrupados.get(chave);
+            boolean possuiAgendamentoNaSemana = agendadosDia != null && agendadosDia.containsKey(horario.getHorario());
+
+            if (possuiAgendamentoNaSemana) {
+                continue;
+            }
+
+            boolean possuiAgendamentoFuturo = agendamentoRepository.existsByHoraAndDiaSemanaAndCategoria(
+                    horario.getHorario(),
+                    horario.getDia(),
+                    horario.getCategoria()
+            );
+
+            if (!possuiAgendamentoFuturo) {
+                horario.setStatus(HorarioStatus.DISPONIVEL);
+                liberados.add(horario);
+            }
+        }
+
+        if (!liberados.isEmpty()) {
+            horarioRepository.saveAll(liberados);
+            logger.info(
+                    "Horários liberados automaticamente para a semana de {} a {}. {} registros atualizados.",
+                    inicioSemana,
+                    fimSemana,
+                    liberados.size()
+            );
+        }
+    }
+
+    @Transactional
     public Map<String, Map<String, List<Horario>>> getTodosHorarios() {
+        liberarHorariosSemanaAtual();
+
         ConfiguracaoAgendamento config = configuracaoAgendamentoService.buscarConfiguracao();
         Map<String, Map<String, List<Horario>>> horarios = new HashMap<>();
         String[] categorias = {"GRADUADO", "OFICIAL"};
@@ -240,8 +290,7 @@ public class HorarioService {
         }
         String status = raw.toUpperCase();
         return switch (status) {
-            case "AGENDADO", "INDISPONIVEL" -> status;
-            case "REALIZADO" -> "AGENDADO";
+            case "AGENDADO", "INDISPONIVEL", "REALIZADO", "REAGENDADO" -> status;
             default -> "DISPONIVEL";
         };
     }
@@ -274,7 +323,7 @@ public class HorarioService {
             Agendamento agendamento = agendados.get(h.getHorario());
             if (agendamento != null) {
                 dto.setUsuarioId(agendamento.getMilitar().getId());
-                status = "AGENDADO";
+                status = agendamento.getStatus();
             }
 
             dto.setStatus(normalizeStatus(status));


### PR DESCRIPTION
## Summary
- automatically release stale weekly slots when listing schedules without touching future bookings
- expose a repository helper to fetch AGENDADO records leveraged by the cleanup routine
- propagate the stored agendamento status so realized appointments remain labeled as such in the admin tables

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e547c7073c8323bf5d5e1c41fd4218