### PR TITLE
Fix rescheduling block after absence justification approval

### DIFF
--- a/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/repositories/AgendamentoRepository.java
@@ -48,17 +48,14 @@ public interface AgendamentoRepository extends JpaRepository<Agendamento, Long> 
     List<Agendamento> findByStatus(String status);
 
 
-    @Query("SELECT a FROM Agendamento a WHERE a.militar.saram = :saram AND a.status IN ('AGENDADO', 'REALIZADO', 'REAGENDADO') ORDER BY a.data DESC")
+    @Query("SELECT a FROM Agendamento a WHERE a.militar.saram = :saram AND a.status IN ('AGENDADO', 'REALIZADO') ORDER BY a.data DESC")
     Optional<Agendamento> findUltimoAgendamentoBySaram(@Param("saram") String saram);
 
-    @Query("""
-            SELECT a FROM Agendamento a
-            JOIN FETCH a.militar
-            WHERE a.militar.id = :militarId
-              AND a.status IN ('AGENDADO', 'REALIZADO', 'REAGENDADO')
-            ORDER BY a.data DESC
-            """)
-    Optional<Agendamento> findUltimoAgendamentoAtivoByMilitarId(@Param("militarId") Long militarId);
+    @EntityGraph(attributePaths = "militar")
+    Optional<Agendamento> findFirstByMilitarIdAndStatusInOrderByDataDescHoraDescIdDesc(
+            Long militarId,
+            List<String> status
+    );
 
     boolean existsByMilitarSaramAndDataGreaterThanEqual(String saram, LocalDate data);
 

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/AgendamentoService.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/AgendamentoService.java
@@ -49,6 +49,8 @@ public class AgendamentoService {
 
     private final MilitarRepository militarRepository;
 
+    private static final List<String> STATUS_ATIVOS_PARA_BLOQUEIO = List.of("AGENDADO", "REALIZADO");
+
     public AgendamentoService(AgendamentoRepository agendamentoRepository,
                               HorarioRepository horarioRepository,
                               ConfiguracaoAgendamentoService configuracaoAgendamentoService,
@@ -76,7 +78,8 @@ public class AgendamentoService {
             return;
         }
 
-        LocalDate ultimaData = agendamentoRepository.findUltimoAgendamentoAtivoByMilitarId(militar.getId())
+        LocalDate ultimaData = agendamentoRepository
+            .findFirstByMilitarIdAndStatusInOrderByDataDescHoraDescIdDesc(militar.getId(), STATUS_ATIVOS_PARA_BLOQUEIO)
             .map(Agendamento::getData)
             .orElse(null);
 
@@ -84,6 +87,10 @@ public class AgendamentoService {
             militar.setUltimoAgendamento(ultimaData);
             militarRepository.save(militar);
         }
+    }
+
+    public void recalcularUltimoAgendamentoDoMilitar(Militar militar) {
+        atualizarUltimoAgendamentoDoMilitar(militar);
     }
 
     @Transactional

--- a/backend/src/main/java/intraer/ccabr/barbearia_api/services/JustificativaAusenciaService.java
+++ b/backend/src/main/java/intraer/ccabr/barbearia_api/services/JustificativaAusenciaService.java
@@ -6,7 +6,6 @@ import intraer.ccabr.barbearia_api.models.JustificativaAusencia;
 import intraer.ccabr.barbearia_api.models.Militar;
 import intraer.ccabr.barbearia_api.repositories.AgendamentoRepository;
 import intraer.ccabr.barbearia_api.repositories.JustificativaAusenciaRepository;
-import intraer.ccabr.barbearia_api.repositories.MilitarRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -25,16 +24,13 @@ public class JustificativaAusenciaService {
 
     private final JustificativaAusenciaRepository repository;
     private final AgendamentoRepository agendamentoRepository;
-    private final MilitarRepository militarRepository;
     private final AgendamentoService agendamentoService;
 
     public JustificativaAusenciaService(JustificativaAusenciaRepository repository,
                                         AgendamentoRepository agendamentoRepository,
-                                        MilitarRepository militarRepository,
                                         AgendamentoService agendamentoService) {
         this.repository = repository;
         this.agendamentoRepository = agendamentoRepository;
-        this.militarRepository = militarRepository;
         this.agendamentoService = agendamentoService;
     }
 
@@ -116,8 +112,7 @@ public class JustificativaAusenciaService {
         }
 
         Militar militar = justificativa.getMilitar();
-        militar.setUltimoAgendamento(null);
-        militarRepository.save(militar);
+        agendamentoService.recalcularUltimoAgendamentoDoMilitar(militar);
 
         return repository.save(justificativa);
     }


### PR DESCRIPTION
## Summary
- stop considering REAGENDADO appointments when computing the last active booking for a militar
- expose a service helper to recalculate the last booking and invoke it when approving an absence justification so users can schedule again
- fetch the latest active appointment with a derived query that only returns a single record to avoid duplicate-result errors

## Testing
- ./mvnw test > /tmp/mvn-test.log && tail -n 20 /tmp/mvn-test.log

------
https://chatgpt.com/codex/tasks/task_e_68e671bc95dc83238e41c28548c232c1